### PR TITLE
fix getTokenById return type

### DIFF
--- a/src/vwbl/VWBL.ts
+++ b/src/vwbl/VWBL.ts
@@ -14,7 +14,7 @@ import {
 import { getMimeType, toBase64FromBlob } from "../util/imageEditor";
 import { VWBLApi } from "./api";
 import { signToProtocol, VWBLNFT } from "./blockchain";
-import { ExtractMetadata, Metadata, PlainMetadata } from "./metadata";
+import { ExtractMetadata, ExtractMetadataAndOwner, Metadata, MetadataAndOwner, PlainMetadata } from "./metadata";
 import {
   EncryptLogic,
   ManageKeyType,
@@ -258,7 +258,7 @@ export class VWBL {
    * @param tokenId - The ID of NFT
    * @returns Token metadata and an address of NFT owner
    */
-  getTokenById = async (tokenId: number): Promise<(ExtractMetadata | Metadata) & { owner: string }> => {
+  getTokenById = async (tokenId: number): Promise<(ExtractMetadataAndOwner | MetadataAndOwner)> => {
     const isOwnerOrMinter = (await this.nft.isOwnerOf(tokenId)) || (await this.nft.isMinterOf(tokenId));
     const owner = await this.nft.getOwner(tokenId);
     const metadata = isOwnerOrMinter ? await this.extractMetadata(tokenId) : await this.getMetadata(tokenId);

--- a/src/vwbl/metadata/type.ts
+++ b/src/vwbl/metadata/type.ts
@@ -24,3 +24,11 @@ export type ExtractMetadata = Metadata & {
   ownDataBase64: string[]
   ownFiles: ArrayBuffer[];
 };
+
+export type MetadataAndOwner = Metadata & {
+  owner: string
+};
+
+export type ExtractMetadataAndOwner = ExtractMetadata & {
+  owner: string
+};


### PR DESCRIPTION
ExtractMetadata | Metadata) & { owner: string } => ExtractMetadta & {owner: string}にtype castしたらコンパイルエラーになるため。