### PR TITLE
feat: add actions for checking package can be published

### DIFF
--- a/.github/workflows/check-can-publish.yml
+++ b/.github/workflows/check-can-publish.yml
@@ -1,0 +1,30 @@
+name: Check package can be published
+
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  # Check available versions below
+  # https://github.com/actions/node-versions/blob/main/versions-manifest.json
+  node-version: "16.x"
+
+jobs:
+  check-can-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          cache: "yarn"
+          node-version: ${{ env.node-version }}
+          registry-url: "https://registry.npmjs.org"
+          always-auth: true
+
+      - name: npx can-npm-publish
+        run: npx can-npm-publish

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vwbl-sdk",
   "description": "VWBL SDK for TypeScript",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [


### PR DESCRIPTION
### パッケージバージョン
0.1.1 => 0.1.2

### 対応内容
- [x] `master`ブランチへのPRに対し、npm publishできる状態かどうかをcheckするactionを追加